### PR TITLE
Add OpenRAM adapter

### DIFF
--- a/src/rtl/sram_width_converter.v
+++ b/src/rtl/sram_width_converter.v
@@ -1,0 +1,34 @@
+`default_nettype none
+module sram_width_converter
+  #(parameter aw = 10)
+  (
+   input wire 		i_clk,
+   //8-bit Subservient interface
+   input wire [aw-1:0] 	i_sram_waddr,
+   input wire [7:0] 	i_sram_wdata,
+   input wire 		i_sram_wen,
+   input wire [aw-1:0] 	i_sram_raddr,
+   output wire [7:0] 	o_sram_rdata,
+   input wire 		i_sram_ren,
+   //32-bit OpenRAM interface
+   output wire 		o_csb0,
+   output wire 		o_web0,
+   output wire [3:0] 	o_wmask0,
+   output wire [aw-3:0] o_addr0,
+   output wire [32:0] 	o_din0,
+   input wire [32:0] 	i_dout0);
+
+   assign o_csb0 = !(i_sram_wen | i_sram_ren);
+   assign o_web0 = !i_sram_wen;
+   assign o_wmask0 = 4'd1 << i_sram_waddr[1:0]; //Decode address LSB to write mask
+   assign o_addr0 = i_sram_wen ? i_sram_waddr[aw-1:2] : i_sram_raddr[aw-1:2]; //Memory is 32-bit word-addressed. Cut off 2 LSB
+   assign o_din0  = {1'b0,{4{i_sram_wdata}}}; //Mirror write data to all byte lanes
+
+   reg [1:0] 		sram_bsel;
+   always @(posedge i_clk)
+     sram_bsel <= i_sram_raddr[1:0];
+
+   assign o_sram_rdata = i_dout0[sram_bsel*8+:8]; //Pick the right byte from the read data
+
+endmodule
+`default_nettype wire

--- a/src/rtl/subservient_openram_if.v
+++ b/src/rtl/subservient_openram_if.v
@@ -1,0 +1,93 @@
+`default_nettype none
+
+module subservient_openram_if
+  (
+`ifdef USE_POWER_PINS
+   inout vccd1,
+   inout vssd1,
+`endif
+   input	 wb_clk_i,
+   input 	 wb_rst_i,
+   input wbs_stb_i,
+   input wbs_cyc_i,
+   input 		 wbs_we_i,
+   input [3:0] wbs_sel_i,
+   input [31:0] wbs_dat_i,
+   input [31:0] wbs_adr_i,
+   output 		 wbs_ack_o,
+   output [31:0] wbs_dat_o,
+
+   output wire 	 csb0,
+   output wire 	 web0,
+   output wire [3:0] 	 wmask0,
+   output wire [aw-3:0] addr0,
+   output wire [32:0] 	 din0,
+   input wire [32:0] 	 dout0,
+   
+   input la_data_in,
+   output io_out,
+   output io_oeb,
+   output [2:0] irq);
+
+   localparam memsize = 1024;
+   localparam aw      = $clog2(memsize);
+
+   wire [aw-1:0] sram_waddr;
+   wire [7:0] 	 sram_wdata;
+   wire 	 sram_wen;
+   wire [aw-1:0] sram_raddr;
+   wire [7:0] 	 sram_rdata;
+   wire 	 sram_ren;
+
+
+   assign io_oeb = wb_rst_i;
+   assign irq    = 3'b000;
+
+   //Adapt the 8-bit SRAM interface from subservient to the 32-bit OpenRAM instance
+   sram_width_converter sram_width_converter
+     (
+      .i_clk (wb_clk_i),
+      //8-bit Subservient interface
+      .i_sram_waddr (sram_waddr),
+      .i_sram_wdata (sram_wdata),
+      .i_sram_wen   (sram_wen),
+      .i_sram_raddr (sram_raddr),
+      .o_sram_rdata (sram_rdata),
+      .i_sram_ren   (sram_ren),
+      //32-bit OpenRAM interface
+      .o_csb0   (csb0),
+      .o_web0   (web0),
+      .o_wmask0 (wmask0),
+      .o_addr0  (addr0),
+      .o_din0   (din0),
+      .i_dout0  (dout0));
+
+   subservient
+     #(.memsize(memsize),
+       .aw(aw))
+   subservient_inst
+     (// Clock & reset
+      .i_clk (wb_clk_i),
+      .i_rst (wb_rst_i),
+      //SRAM interface
+      .o_sram_waddr (sram_waddr),
+      .o_sram_wdata (sram_wdata),
+      .o_sram_wen   (sram_wen),
+      .o_sram_raddr (sram_raddr),
+      .i_sram_rdata (sram_rdata),
+      .o_sram_ren   (sram_ren),
+      //Debug interface
+      .i_debug_mode (~la_data_in),
+      .i_wb_dbg_adr (wbs_adr_i),
+      .i_wb_dbg_dat (wbs_dat_i),
+      .i_wb_dbg_sel (wbs_sel_i),
+      .i_wb_dbg_we  (wbs_we_i),
+      .i_wb_dbg_stb (wbs_stb_i),
+      .o_wb_dbg_rdt (wbs_dat_o),
+      .o_wb_dbg_ack (wbs_ack_o),
+      // External I/O
+      .o_gpio (io_out));
+
+endmodule
+
+`default_nettype wire

--- a/src/rtl/subservient_wrapped.v
+++ b/src/rtl/subservient_wrapped.v
@@ -20,7 +20,7 @@ module subservient_wrapped (
                             output io_oeb,
                             output [2:0] irq);
     
-    localparam memsize = 512;
+    localparam memsize = 1024;
     localparam aw      = $clog2(memsize);
     
     wire [aw-1:0] sram_waddr;
@@ -30,18 +30,47 @@ module subservient_wrapped (
     wire [7:0] 	  sram_rdata;
     wire 	        sram_ren;
     
+   wire 	 csb0;
+   wire 	 web0;
+   wire [3:0] 	 wmask0;
+   wire [aw-3:0] addr0;
+   wire [32:0] 	 din0;
+   wire [32:0] 	 dout0;
+
     assign io_oeb = wb_rst_i;
     assign irq    = 3'b000;
     
-    ff_ram #(.memsize(memsize), .aw(aw)) sram (
-    .reset (wb_rst_i),
-    .clk   (wb_clk_i),
-    .wen   (sram_wen),
-    .waddr (sram_waddr),
-    .din   (sram_wdata),
-    .raddr (sram_raddr),
-    .dout  (sram_rdata)
-    );
+   sky130_sram_1kbyte_1rw_32x256_8
+     #(.VERBOSE (0))
+   sram
+     (
+      .clk0       (wb_clk_i),
+      .csb0       (csb0),
+      .web0       (web0),
+      .wmask0     (wmask0),
+      .spare_wen0 (1'b0),
+      .addr0      ({1'b0,addr0}),
+      .din0       (din0),
+      .dout0      (dout0));
+
+   //Adapt the 8-bit SRAM interface from subservient to the 32-bit OpenRAM instance
+   sram_width_converter sram_width_converter
+     (
+      .i_clk (wb_clk_i),
+      //8-bit Subservient interface
+      .i_sram_waddr (sram_waddr),
+      .i_sram_wdata (sram_wdata),
+      .i_sram_wen   (sram_wen),
+      .i_sram_raddr (sram_raddr),
+      .o_sram_rdata (sram_rdata),
+      .i_sram_ren   (sram_ren),
+      //32-bit OpenRAM interface
+      .o_csb0   (csb0),
+      .o_web0   (web0),
+      .o_wmask0 (wmask0),
+      .o_addr0  (addr0),
+      .o_din0   (din0),
+      .i_dout0  (dout0));
     
     subservient #(.memsize(memsize), .aw(aw)) subservient_inst
     (

--- a/src/tb/subservient_wrapped_tb.v
+++ b/src/tb/subservient_wrapped_tb.v
@@ -7,8 +7,8 @@
 
 `default_nettype none
 
-`include "/home/klasn/mpw4/OpenLane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/verilog/primitives.v"
-`include "/home/klasn/mpw4/OpenLane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v"
+//`include "/home/klasn/mpw4/OpenLane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/verilog/primitives.v"
+//`include "/home/klasn/mpw4/OpenLane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v"
 //`include "/home/klasn/mpw4/OpenLane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fakediode_2.v"
 
 module subservient_wrapper_tb; 

--- a/subservient_wrapped.core
+++ b/subservient_wrapped.core
@@ -5,10 +5,11 @@ name : ::subservient_wrapped:1.0.0
 filesets:
     source:
         files:
-            - src/rtl/ff_ram.v
+#            - src/rtl/ff_ram.v
+            - src/rtl/sram_width_converter.v
             - src/rtl/subservient_wrapped.v
         file_type : verilogSource
-        depend : [subservient]
+        depend : [subservient, efabless:sky130_sram:1kbyte_1rw_32x256_8]
 
     gl:
         files:
@@ -34,9 +35,17 @@ filesets:
             - src/sw/hello.hex  : {copyto : hello.hex}
         file_type : user
 
+    openram_if:
+      files: [src/rtl/subservient_openram_if.v : {file_type : verilogSource}]
+
 targets:
     default:
         filesets : [source]
+
+    openram_if:
+        default_tool : openlane
+        filesets : [source, openram_if, config]
+        toplevel : subservient_wrapped
 
     sky130:
         default_tool : openlane


### PR DESCRIPTION
Replace ff_ram with an openram instance + adapter. Relies on an openram core description file that isn't upstream. In the meantime, use https://github.com/efabless/sky130_sram_macros and put

```
CAPI=2:

name : efabless:sky130_sram:1kbyte_1rw_32x256_8

filesets:
  verilog:
    files: [sky130_sram_1kbyte_1rw_32x256_8.v : {file_type : verilogSource}]

targets:
  default :
    filesets: [verilog]
```

into `sky130_sram_1kbyte_1rw_32x256_8/sky130_sram_1kbyte_1rw.core`

